### PR TITLE
Fix crit on advantage attack

### DIFF
--- a/src/hasterolls5e.js
+++ b/src/hasterolls5e.js
@@ -63,10 +63,32 @@ function autoRollDamage(rolls, data) {
     // get original Activity message
     const attackMessage = rolls[0].parent;
     const messageId = attackMessage.getFlag("dnd5e", "originatingMessage");
-    // simulate a click on the Activity message's Damage button
-    const activityMessage = document.querySelector(`#chat li[data-message-id="${messageId}"]`);
-    activityMessage?.querySelector('button[data-action="rollDamage"]')?.click();
+    // roll damage similar to clicking on the Damage button
+    _rollDamage.call(data.subject, game.messages.get(messageId));
   }
+}
+
+/* Adapted from AttackActivity's private #rollDamage function */
+function _rollDamage(message) {
+  const lastAttack = message.getAssociatedRolls("attack").pop();
+  const attackMode = lastAttack?.getFlag("dnd5e", "roll.attackMode");
+
+  // Fetch the ammunition used with the last attack roll
+  let ammunition;
+  const actor = lastAttack?.getAssociatedActor();
+  if ( actor ) {
+    const storedData = lastAttack.getFlag("dnd5e", "roll.ammunitionData");
+    ammunition = storedData
+      ? new Item.implementation(storedData, { parent: actor })
+      : actor.items.get(lastAttack.getFlag("dnd5e", "roll.ammunition"));
+  }
+
+  const isCritical = lastAttack?.rolls[0]?.isCritical;
+  const dialogConfig = {};
+  if ( isCritical ) dialogConfig.options = { defaultButton: "critical" };
+
+  // intentionally not passing in an event so holding ALT for advantage on attack doesn't turn damage into a crit
+  this.rollDamage({ ammunition, attackMode, isCritical }, dialogConfig);
 }
 
 function postUseActivity(activity, usageConfig, results) {

--- a/src/hasterolls5e.js
+++ b/src/hasterolls5e.js
@@ -130,6 +130,7 @@ async function triggerSubsequentActions(config, results) {
     const dialogConfig = {};
     if ( isCritical ) dialogConfig.options = { defaultButton: "critical" };
 
-    this.rollDamage({ event: config.event, ammunition, attackMode, isCritical }, dialogConfig);
+    // intentionally not passing in an event so holding ALT for advantage on attack doesn't turn damage into a crit
+    this.rollDamage({ ammunition, attackMode, isCritical }, dialogConfig);
   }
 }


### PR DESCRIPTION
When holding ALT to roll an attack w/ advantage, if the damage was auto-rolled, it would roll a critical hit always because you were holding ALT. When auto-rolling damage dice, stop passing in the `event` so holding ALT (or CTRL) won't affect the damage roll. Fixes #5