### PR TITLE
Skip activity usage dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 _The Haste spell for your rolls in D&D 5e_
 
-This Foundry VTT module for the D&D 5e system lets you skip roll configuration dialogs for speedier play. That goes for D20 Tests, damage, and healing rolls. You can still show the dialog if you want by holding down the Skip Dialog key (Shift by default). It can also be configured to automatically trigger the damage roll if the attack roll hits.
+This Foundry VTT module for the D&D 5e system lets you skip roll configuration dialogs for speedier play. That goes for D20 Tests, damage, and healing rolls. You can still show the dialog if you want by holding down the Skip Dialog key (Shift by default). It can also be configured to automatically trigger the damage roll if the attack roll hits. Can also configure it to skip the activity usage dialog where you confirm Consumption, Concentration, etc.

--- a/lang/en.json
+++ b/lang/en.json
@@ -4,6 +4,10 @@
       "name": "Skip Roll Configuration Dialogs",
       "hint": "Skip the roll configuration dialog when rolling D20 Tests, damage, and healing rolls. Hold Shift to show the dialogs."
     },
+    "skipActivityUsage": {
+      "name": "Skip Activity Usage Dialog",
+      "hint": "Skip the activity usage dialog where you confirm Consumption, Concentration, etc. Hold Shift to show the dialog."
+    },
     "autoRollDamage": {
       "name": "Auto Roll Damage",
       "hint": "Automatically trigger the damage roll if the attack roll hits. For players, will only happen if Attack Roll Visibility is enabled."

--- a/src/hasterolls5e.js
+++ b/src/hasterolls5e.js
@@ -11,6 +11,16 @@ Hooks.once("init", () => {
     default: true,
   });
 
+  game.settings.register("hasterolls5e", "skipActivityUsage", {
+    name: "hasterolls5e.skipActivityUsage.name",
+    hint: "hasterolls5e.skipActivityUsage.hint",
+    scope: "client",
+    config: true,
+    requiresReload: false,
+    type: Boolean,
+    default: false,
+  });
+
   game.settings.register("hasterolls5e", "autoRollDamage", {
     name: "hasterolls5e.autoRollDamage.name",
     hint: "hasterolls5e.autoRollDamage.hint",
@@ -30,18 +40,22 @@ Hooks.once("init", () => {
 });
 
 Hooks.on("dnd5e.preRollD20TestV2", (config, dialog, message) => {
-  handleRoll(config, dialog);
+  handleRoll(config, dialog, "skipRollConfig");
 });
 
 Hooks.on("dnd5e.preRollDamageV2", (config, dialog, message) => {
-  handleRoll(config, dialog);
+  handleRoll(config, dialog, "skipRollConfig");
 });
 
-function handleRoll(config, dialog) {
+Hooks.on("dnd5e.preUseActivity", (activity, usageConfig, dialogConfig, messageConfig) => {
+  handleRoll(usageConfig, dialogConfig, "skipActivityUsage");
+});
+
+function handleRoll(config, dialog, settingKey) {
   // system version 5.1.0 changed the key presses so now shift+alt, for example, forces advantage
   // tweak it so only holding Shift shows the dialog
   const system51 = foundry.utils.isNewerVersion(game.system.version, "5.0.99");
-  const skipRollConfig = game.settings.get("hasterolls5e", "skipRollConfig");
+  const skipRollConfig = game.settings.get("hasterolls5e", settingKey);
   if (system51 && skipRollConfig) {
     const normal = dnd5e.utils.areKeysPressed(config.event, "skipDialogNormal");
     const advantage = dnd5e.utils.areKeysPressed(config.event, "skipDialogAdvantage");


### PR DESCRIPTION
Add option to skip the activity usage dialog. That's the dialog where you confirm consumption (item uses, spell slots) concentration, etc.